### PR TITLE
updates spring gem to 1.3.4 due to error "/Users/hawley/.rvm/gems/ruby-2...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '4.2.0'
 
 gem 'rails-api'
 
-gem 'spring', :group => :development
+gem 'spring', '1.3.4', :group => :development
 
 gem 'rack-cors'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
-    spring (1.3.3)
+    spring (1.3.4)
     sprockets (2.12.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -111,4 +111,4 @@ DEPENDENCIES
   rack-cors
   rails (= 4.2.0)
   rails-api
-  spring
+  spring (= 1.3.4)


### PR DESCRIPTION
....2.0@global/gems/bundler-1.7.12/lib/bundler/runtime.rb:34:in `block in setup': You have already activated spring 1.3.4, but your Gemfile requires spring 1.3.3. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)"